### PR TITLE
bug/arcsi-v1-name-2dp-issue

### DIFF
--- a/workflow/app/workflows/process_s2_swath/OldFilenameHandler.py
+++ b/workflow/app/workflows/process_s2_swath/OldFilenameHandler.py
@@ -77,6 +77,13 @@ class OldFilenameHandler():
         roundedLatString = str(roundedLat).replace('.', '')
         roundedLonString = str(roundedLon).replace('.', '')
 
+        # Workaround for version 1 arcsi naming convnetion.
+        # Need to handle specific cases where 3 significant figure longitudes that end with a trailing zero,
+        # need to be trimmed to 2 Significant figures.
+        # this is align filenames with an older version of arcsi.
+        if len(roundedLonString) == 3 and roundedLonString.endswith('0'):
+            roundedLonString = roundedLonString[0:2]
+
         latLonString = f"lat{roundedLatString}lon{roundedLonString}"
 
         return latLonString

--- a/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_meta.json
+++ b/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_meta.json
@@ -1,0 +1,114 @@
+{
+    "AcquasitionInfo": {
+        "Date": {
+            "Day": 27,
+            "Month": 1,
+            "Year": 2022
+        },
+        "SolarAzimuth": 167.273174669652,
+        "SolarZenith": 74.6588125781441,
+        "Time": {
+            "Hour": 11,
+            "Minute": 33,
+            "Second": 9
+        },
+        "sensorAzimuth": 196.9638094558563,
+        "sensorZenith": 2.8344177205166807
+    },
+    "FileInfo": {
+        "CLOUD_MASK": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_clouds.kea",
+        "FileBaseName": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n",
+        "IMAGE_DEM": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_dem.kea",
+        "METADATA": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_meta.json",
+        "ProviderMetadata": "MTD_MSIL1C.xml",
+        "RADIANCE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_rad.kea",
+        "RADIANCE_WHOLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad.kea",
+        "SREF_6S_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem.kea",
+        "SREF_6S_WHOLE_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "SREF_DOS_IMG_WHOLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "STD_SREF_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem_stdsref.kea",
+        "STD_SREF_WHOLE_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_srefdem_stdsref.kea",
+        "TOA": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_rad_toa.kea",
+        "TOA_WHOLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_toa.kea",
+        "TOPO_SHADOW_MASK": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_toposhad.kea",
+        "VALID_MASK": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_valid.kea",
+        "VIEW_ANGLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_viewangle.kea"
+    },
+    "LocationInfo": {
+        "Geographical": {
+            "BBOX": {
+                "BLLat": 54.94906599009572,
+                "BLLon": -4.561981726975494,
+                "BRLat": 54.959003358478256,
+                "BRLon": -2.8475802889841417,
+                "TLLat": 55.93532706093329,
+                "TLLon": -4.6014369143364435,
+                "TRLat": 55.94563532105239,
+                "TRLon": -2.8437282507299404
+            },
+            "CentreLat": 55.45035593784562,
+            "CentreLon": -3.713681905950225
+        },
+        "Projected": {
+            "BBOX": {
+                "BLX": 236020.0,
+                "BLY": 563040.0,
+                "BRX": 347400.0,
+                "BRY": 563040.0,
+                "TLX": 236020.0,
+                "TLY": 674420.0,
+                "TRX": 347400.0,
+                "TRY": 674420.0
+            },
+            "CentreX": 291710.0,
+            "CentreY": 618730.0,
+            "VPOLY": {
+                "MaxXX": 347400.0,
+                "MaxXY": 672820.0,
+                "MaxYX": 237610.0,
+                "MaxYY": 674420.0,
+                "MinXX": 236020.0,
+                "MinXY": 565100.0,
+                "MinYX": 345210.0,
+                "MinYY": 563040.0
+            }
+        }
+    },
+    "ProductsInfo": {
+        "ARCSIProducts": [
+            "RAD",
+            "SHARP",
+            "SATURATE",
+            "CLOUDS",
+            "TOPOSHADOW",
+            "STDSREF",
+            "DOSAOTSGL",
+            "METADATA"
+        ],
+        "ARCSI_AOT_RANGE_MAX": 0.5,
+        "ARCSI_AOT_RANGE_MIN": 0.05,
+        "ARCSI_AOT_VALUE": 0.05,
+        "ARCSI_CLOUD_COVER": 0.639990508556366,
+        "ARCSI_LUT_ELEVATION_MAX": 900,
+        "ARCSI_LUT_ELEVATION_MIN": 0,
+        "ProcessDate": {
+            "Day": 14,
+            "Month": 1,
+            "Year": 2023
+        },
+        "ProcessTime": {
+            "Hour": 1,
+            "Minute": 33,
+            "Second": 33
+        },
+        "REPROJECT": "PROJCS[\"OSGB 1936 / British National Grid\",GEOGCS[\"OSGB 1936\",DATUM[\"OSGB_1936\",SPHEROID[\"Airy 1830\",6377563.396,299.3249646,AUTHORITY[\"EPSG\",\"7001\"]],AUTHORITY[\"EPSG\",\"6277\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4277\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",49],PARAMETER[\"central_meridian\",-2],PARAMETER[\"scale_factor\",0.9996012717],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",-100000],AUTHORITY[\"EPSG\",\"27700\"],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]"
+    },
+    "SensorInfo": {
+        "ARCSISensorName": "SEN2"
+    },
+    "SoftwareInfo": {
+        "Name": "ARCSI",
+        "URL": "https://github.com/remotesensinginfo/arcsi",
+        "Version": "4.0.2"
+    }
+}

--- a/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220620_latn509lonw0008_T30UXB_ORB137_20220620132116_utm30n_osgb_meta.json
+++ b/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220620_latn509lonw0008_T30UXB_ORB137_20220620132116_utm30n_osgb_meta.json
@@ -1,0 +1,114 @@
+{
+    "AcquasitionInfo": {
+        "Date": {
+            "Day": 27,
+            "Month": 1,
+            "Year": 2022
+        },
+        "SolarAzimuth": 167.273174669652,
+        "SolarZenith": 74.6588125781441,
+        "Time": {
+            "Hour": 11,
+            "Minute": 33,
+            "Second": 9
+        },
+        "sensorAzimuth": 196.9638094558563,
+        "sensorZenith": 2.8344177205166807
+    },
+    "FileInfo": {
+        "CLOUD_MASK": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_clouds.kea",
+        "FileBaseName": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n",
+        "IMAGE_DEM": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_dem.kea",
+        "METADATA": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_meta.json",
+        "ProviderMetadata": "MTD_MSIL1C.xml",
+        "RADIANCE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_rad.kea",
+        "RADIANCE_WHOLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad.kea",
+        "SREF_6S_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem.kea",
+        "SREF_6S_WHOLE_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "SREF_DOS_IMG_WHOLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "STD_SREF_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem_stdsref.kea",
+        "STD_SREF_WHOLE_IMG": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_srefdem_stdsref.kea",
+        "TOA": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_mclds_rad_toa.kea",
+        "TOA_WHOLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_vmsk_sharp_rad_toa.kea",
+        "TOPO_SHADOW_MASK": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_toposhad.kea",
+        "VALID_MASK": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_valid.kea",
+        "VIEW_ANGLE": "SEN2_20220127_latn555lonw0037_T30UVG_ORB080_20220127121733_utm30n_osgb_viewangle.kea"
+    },
+    "LocationInfo": {
+        "Geographical": {
+            "BBOX": {
+                "BLLat": 54.94906599009572,
+                "BLLon": -4.561981726975494,
+                "BRLat": 54.959003358478256,
+                "BRLon": -2.8475802889841417,
+                "TLLat": 55.93532706093329,
+                "TLLon": -4.6014369143364435,
+                "TRLat": 55.94563532105239,
+                "TRLon": -2.8437282507299404
+            },
+            "CentreLat": 55.45035593784562,
+            "CentreLon": -3.713681905950225
+        },
+        "Projected": {
+            "BBOX": {
+                "BLX": 236020.0,
+                "BLY": 563040.0,
+                "BRX": 347400.0,
+                "BRY": 563040.0,
+                "TLX": 236020.0,
+                "TLY": 674420.0,
+                "TRX": 347400.0,
+                "TRY": 674420.0
+            },
+            "CentreX": 291710.0,
+            "CentreY": 618730.0,
+            "VPOLY": {
+                "MaxXX": 347400.0,
+                "MaxXY": 672820.0,
+                "MaxYX": 237610.0,
+                "MaxYY": 674420.0,
+                "MinXX": 236020.0,
+                "MinXY": 565100.0,
+                "MinYX": 345210.0,
+                "MinYY": 563040.0
+            }
+        }
+    },
+    "ProductsInfo": {
+        "ARCSIProducts": [
+            "RAD",
+            "SHARP",
+            "SATURATE",
+            "CLOUDS",
+            "TOPOSHADOW",
+            "STDSREF",
+            "DOSAOTSGL",
+            "METADATA"
+        ],
+        "ARCSI_AOT_RANGE_MAX": 0.5,
+        "ARCSI_AOT_RANGE_MIN": 0.05,
+        "ARCSI_AOT_VALUE": 0.05,
+        "ARCSI_CLOUD_COVER": 0.639990508556366,
+        "ARCSI_LUT_ELEVATION_MAX": 900,
+        "ARCSI_LUT_ELEVATION_MIN": 0,
+        "ProcessDate": {
+            "Day": 14,
+            "Month": 1,
+            "Year": 2023
+        },
+        "ProcessTime": {
+            "Hour": 1,
+            "Minute": 33,
+            "Second": 33
+        },
+        "REPROJECT": "PROJCS[\"OSGB 1936 / British National Grid\",GEOGCS[\"OSGB 1936\",DATUM[\"OSGB_1936\",SPHEROID[\"Airy 1830\",6377563.396,299.3249646,AUTHORITY[\"EPSG\",\"7001\"]],AUTHORITY[\"EPSG\",\"6277\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4277\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",49],PARAMETER[\"central_meridian\",-2],PARAMETER[\"scale_factor\",0.9996012717],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",-100000],AUTHORITY[\"EPSG\",\"27700\"],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]"
+    },
+    "SensorInfo": {
+        "ARCSISensorName": "SEN2"
+    },
+    "SoftwareInfo": {
+        "Name": "ARCSI",
+        "URL": "https://github.com/remotesensinginfo/arcsi",
+        "Version": "4.0.2"
+    }
+}

--- a/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_meta.json
+++ b/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_meta.json
@@ -1,0 +1,114 @@
+{
+    "AcquasitionInfo": {
+        "Date": {
+            "Day": 20,
+            "Month": 6,
+            "Year": 2022
+        },
+        "SolarAzimuth": 155.076188131408,
+        "SolarZenith": 30.2166104327254,
+        "Time": {
+            "Hour": 11,
+            "Minute": 6,
+            "Second": 29
+        },
+        "sensorAzimuth": 106.34468223792646,
+        "sensorZenith": 7.800828179350858
+    },
+    "FileInfo": {
+        "CLOUD_MASK": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_clouds.kea",
+        "FileBaseName": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n",
+        "IMAGE_DEM": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_dem.kea",
+        "METADATA": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_meta.json",
+        "ProviderMetadata": "MTD_MSIL1C.xml",
+        "RADIANCE": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_mclds_rad.kea",
+        "RADIANCE_WHOLE": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_rad.kea",
+        "SREF_6S_IMG": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem.kea",
+        "SREF_6S_WHOLE_IMG": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "SREF_DOS_IMG_WHOLE": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "STD_SREF_IMG": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem_stdsref.kea",
+        "STD_SREF_WHOLE_IMG": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_rad_srefdem_stdsref.kea",
+        "TOA": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_mclds_rad_toa.kea",
+        "TOA_WHOLE": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_vmsk_sharp_rad_toa.kea",
+        "TOPO_SHADOW_MASK": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_toposhad.kea",
+        "VALID_MASK": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_valid.kea",
+        "VIEW_ANGLE": "SEN2_20220620_latn519lonw0022_T30UWC_ORB137_20220620132116_utm30n_osgb_viewangle.kea"
+    },
+    "LocationInfo": {
+        "Geographical": {
+            "BBOX": {
+                "BLLat": 51.36324170735066,
+                "BLLon": -3.000287272590171,
+                "BRLat": 51.35263389277857,
+                "BRLon": -1.423481335798042,
+                "TLLat": 52.35047315691463,
+                "TLLon": -3.000293629118639,
+                "TRLat": 52.33948485166988,
+                "TRLon": -1.3886156372173195
+            },
+            "CentreLat": 51.85417975792447,
+            "CentreLon": -2.2031693865190487
+        },
+        "Projected": {
+            "BBOX": {
+                "BLX": 330460.0,
+                "BLY": 161660.0,
+                "BRX": 441750.0,
+                "BRY": 161660.0,
+                "TLX": 330460.0,
+                "TLY": 272690.0,
+                "TRX": 441750.0,
+                "TRY": 272690.0
+            },
+            "CentreX": 386105.0,
+            "CentreY": 217175.0,
+            "VPOLY": {
+                "MaxXX": 441750.0,
+                "MaxXY": 271430.0,
+                "MaxYX": 351820.0,
+                "MaxYY": 272690.0,
+                "MinXX": 330460.0,
+                "MinXY": 163890.0,
+                "MinYX": 440170.0,
+                "MinYY": 161660.0
+            }
+        }
+    },
+    "ProductsInfo": {
+        "ARCSIProducts": [
+            "RAD",
+            "SHARP",
+            "SATURATE",
+            "CLOUDS",
+            "TOPOSHADOW",
+            "STDSREF",
+            "DOSAOTSGL",
+            "METADATA"
+        ],
+        "ARCSI_AOT_RANGE_MAX": 0.5,
+        "ARCSI_AOT_RANGE_MIN": 0.05,
+        "ARCSI_AOT_VALUE": 0.1,
+        "ARCSI_CLOUD_COVER": 0.3225811719894409,
+        "ARCSI_LUT_ELEVATION_MAX": 500,
+        "ARCSI_LUT_ELEVATION_MIN": -100,
+        "ProcessDate": {
+            "Day": 15,
+            "Month": 12,
+            "Year": 2022
+        },
+        "ProcessTime": {
+            "Hour": 11,
+            "Minute": 0,
+            "Second": 39
+        },
+        "REPROJECT": "PROJCS[\"OSGB 1936 / British National Grid\",GEOGCS[\"OSGB 1936\",DATUM[\"OSGB_1936\",SPHEROID[\"Airy 1830\",6377563.396,299.3249646,AUTHORITY[\"EPSG\",\"7001\"]],TOWGS84[446.448,-125.157,542.06,0.15,0.247,0.842,-20.489],AUTHORITY[\"EPSG\",\"6277\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4277\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",49],PARAMETER[\"central_meridian\",-2],PARAMETER[\"scale_factor\",0.9996012717],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",-100000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"27700\"]]"
+    },
+    "SensorInfo": {
+        "ARCSISensorName": "SEN2"
+    },
+    "SoftwareInfo": {
+        "Name": "ARCSI",
+        "URL": "http://www.rsgislib.org/arcsi",
+        "Version": "4.0.0"
+    }
+}

--- a/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_meta.json
+++ b/workflow/app/workflows/process_s2_swath/test/useful-metadata-json-files/SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_meta.json
@@ -1,0 +1,115 @@
+{
+    "AcquasitionInfo": {
+        "Date": {
+            "Day": 20,
+            "Month": 6,
+            "Year": 2022
+        },
+        "SolarAzimuth": 158.15620529572,
+        "SolarZenith": 30.6785570723147,
+        "Time": {
+            "Hour": 11,
+            "Minute": 6,
+            "Second": 29
+        },
+        "sensorAzimuth": 136.84343150662377,
+        "sensorZenith": 3.2993908209151117
+    },
+    "FileInfo": {
+        "CLOUD_MASK": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_clouds.kea",
+        "CLOUD_PROB": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_clouds_prob.kea",
+        "FileBaseName": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n",
+        "IMAGE_DEM": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_dem.kea",
+        "METADATA": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_meta.json",
+        "ProviderMetadata": "MTD_MSIL1C.xml",
+        "RADIANCE": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_mclds_rad.kea",
+        "RADIANCE_WHOLE": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_rad.kea",
+        "SREF_6S_IMG": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem.kea",
+        "SREF_6S_WHOLE_IMG": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "SREF_DOS_IMG_WHOLE": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_rad_srefdem.kea",
+        "STD_SREF_IMG": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_mclds_topshad_rad_srefdem_stdsref.kea",
+        "STD_SREF_WHOLE_IMG": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_rad_srefdem_stdsref.kea",
+        "TOA": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_mclds_rad_toa.kea",
+        "TOA_WHOLE": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_vmsk_sharp_rad_toa.kea",
+        "TOPO_SHADOW_MASK": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_toposhad.kea",
+        "VALID_MASK": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_valid.kea",
+        "VIEW_ANGLE": "SEN2_20220620_latn527lonw0007_T30UXD_ORB137_20220620115229_utm30n_osgb_viewangle.kea"
+    },
+    "LocationInfo": {
+        "Geographical": {
+            "BBOX": {
+                "BLLat": 52.25345680616433,
+                "BLLon": -1.5350196328445171,
+                "BRLat": 52.2225660331335,
+                "BRLon": 0.0716784870337709,
+                "TLLat": 53.24020834899015,
+                "TLLon": -1.5015395716690334,
+                "TRLat": 53.20820137227573,
+                "TRLon": 0.14176990447193422
+            },
+            "CentreLat": 52.733914405811646,
+            "CentreLon": -0.7057774436829716
+        },
+        "Projected": {
+            "BBOX": {
+                "BLX": 432210.0,
+                "BLY": 260280.0,
+                "BRX": 543130.0,
+                "BRY": 260280.0,
+                "TLX": 432210.0,
+                "TLY": 371580.0,
+                "TRX": 543130.0,
+                "TRY": 371580.0
+            },
+            "CentreX": 487670.0,
+            "CentreY": 315930.0,
+            "VPOLY": {
+                "MaxXX": 543130.0,
+                "MaxXY": 370030.0,
+                "MaxYX": 433370.0,
+                "MaxYY": 371580.0,
+                "MinXX": 432210.0,
+                "MinXY": 289040.0,
+                "MinYX": 541540.0,
+                "MinYY": 260280.0
+            }
+        }
+    },
+    "ProductsInfo": {
+        "ARCSIProducts": [
+            "RAD",
+            "SHARP",
+            "SATURATE",
+            "CLOUDS",
+            "TOPOSHADOW",
+            "STDSREF",
+            "DOSAOTSGL",
+            "METADATA"
+        ],
+        "ARCSI_AOT_RANGE_MAX": 0.5,
+        "ARCSI_AOT_RANGE_MIN": 0.05,
+        "ARCSI_AOT_VALUE": 0.15000000000000002,
+        "ARCSI_CLOUD_COVER": 0.6621021032333374,
+        "ARCSI_LUT_ELEVATION_MAX": 400,
+        "ARCSI_LUT_ELEVATION_MIN": -200,
+        "ProcessDate": {
+            "Day": 8,
+            "Month": 2,
+            "Year": 2023
+        },
+        "ProcessTime": {
+            "Hour": 14,
+            "Minute": 4,
+            "Second": 45
+        },
+        "REPROJECT": "PROJCS[\"OSGB 1936 / British National Grid\",GEOGCS[\"OSGB 1936\",DATUM[\"OSGB_1936\",SPHEROID[\"Airy 1830\",6377563.396,299.3249646,AUTHORITY[\"EPSG\",\"7001\"]],TOWGS84[446.448,-125.157,542.06,0.15,0.247,0.842,-20.489],AUTHORITY[\"EPSG\",\"6277\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4277\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",49],PARAMETER[\"central_meridian\",-2],PARAMETER[\"scale_factor\",0.9996012717],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",-100000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"27700\"]]"
+    },
+    "SensorInfo": {
+        "ARCSISensorName": "SEN2"
+    },
+    "SoftwareInfo": {
+        "Name": "ARCSI",
+        "URL": "https://github.com/remotesensinginfo/arcsi",
+        "Version": "4.0.2"
+    }
+}


### PR DESCRIPTION
workaround for version 1 of the arcsi naming convention. An older version of arcsi trimmed longitudes to 2 decimal places when the trailing value was a zero. This patch forces that to happen in the oldFilenameHandler luigi task. This achieves a comporable output name ultimately for the CEDA archive.