### PR TITLE
update base dockerhub image 

### DIFF
--- a/workflow/dockerfile
+++ b/workflow/dockerfile
@@ -1,4 +1,4 @@
-FROM petebunting/au-eoed:20230220
+FROM petebunting/au-eoed:20240729
 
 # Setup app folder
 WORKDIR /app


### PR DESCRIPTION
tag to 20240729 which includes arcsi v4.0.5 (fix for s2 esa baseline 5.11 metadata, see arcsi PR https://github.com/remotesensinginfo/arcsi/pull/13 