### PR TITLE
Remove .SAFE from product name for compatiblity with CDSE downloads

### DIFF
--- a/workflow/app/workflows/process_s2_swath/GetGranuleInfo.py
+++ b/workflow/app/workflows/process_s2_swath/GetGranuleInfo.py
@@ -111,7 +111,7 @@ class GetGranuleInfo(luigi.Task):
         sunAngles = self.getSunAngles(mtdXmlRoot)
         viewingAngles = self.getViewingAngles(mtdXmlRoot)
 
-        productName = os.path.basename(self.productPath)
+        productName = os.path.basename(self.productPath).removesuffix(".SAFE")
 
         splits = productName.split("_")
 


### PR DESCRIPTION
The CDSE download format is a bit different to the mundi download format because the folder names end in ".SAFE". I've made a small change so that you can pass these straight through to the ARD workflow without needing to rename them first. Should be backwards compatible so no changes needed on your side @samfranklin.

I'll be updating the S1 workflow as well - PR to follow tomorrow probably.