### PR TITLE
Adding another dockerfile for building with Intel MPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ The mapped input folder contains a set of S2 granules that will be processed as 
 Build and run instructions
 --------------------------
 
-Build to image:
+Build default OpenMPI image:
 
     cd workflow
     docker build -t s2-ard-processor .
+
+Build IntelMPI image:
+
+    cd workflow
+    docker build -t s2-ard-processor -f intelmpi.dockerfile .
+
 
 Use `--no-cache` to build from scratch
 

--- a/workflow/dockerfile
+++ b/workflow/dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && apt-get -y install \
     apt-utils \
     unzip
 
+# Intel MPI
+RUN conda remove openmpi 
+RUN conda install --yes -c conda-forge mpi4py impi_rt
+
 # --------- Place machine build layers before this line ---------
 
 # Create processing paths

--- a/workflow/intelmpi.dockerfile
+++ b/workflow/intelmpi.dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && apt-get -y install \
     apt-utils \
     unzip
 
+# Intel MPI
+RUN conda remove openmpi 
+RUN conda install --yes -c conda-forge mpi4py=4.0.3 impi_rt=2021.15.0
+
 # --------- Place machine build layers before this line ---------
 
 # Create processing paths


### PR DESCRIPTION
The MPI flavour on JASMIN has changed which means we now need the S2 ARD container to use Intel MPI instead of OpenMPI. Presumably EODS is still using OpenMPI so I've added a separate dockerfile which will be built and published to a separate dockerhub repo so the EODS process can remain the same.